### PR TITLE
Add RealSense D435 model

### DIFF
--- a/px4_fast_planner-master/models/d435_camera/d435_camera.sdf
+++ b/px4_fast_planner-master/models/d435_camera/d435_camera.sdf
@@ -1,0 +1,62 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="d435_camera">
+    <pose>0 0 0.035 0 0 0</pose>
+    <link name="link">
+      <inertial>
+        <pose>0.01 0.025 0.025 0 0 0</pose>
+        <mass>0.01</mass>
+        <inertia>
+          <ixx>4.15e-6</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>2.407e-6</iyy>
+          <iyz>0</iyz>
+          <izz>2.407e-6</izz>
+        </inertia>
+      </inertial>
+      <visual name="visual">
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>model://realsense_camera/meshes/realsense.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <sensor name="depth_camera" type="depth">
+        <update_rate>30</update_rate>
+        <camera>
+          <horizontal_fov>1.48</horizontal_fov>
+          <vertical_fov>1.01</vertical_fov>
+          <image>
+            <format>R8G8B8</format>
+            <width>848</width>
+            <height>480</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>10</far>
+          </clip>
+        </camera>
+        <plugin filename="libgazebo_ros_openni_kinect.so" name="camera_controller">
+          <cameraName>camera</cameraName>
+          <alwaysOn>true</alwaysOn>
+          <updateRate>20</updateRate>
+          <pointCloudCutoff>0.2</pointCloudCutoff>
+          <pointCloudCutoffMax>20</pointCloudCutoffMax>
+          <imageTopicName>rgb/image_raw</imageTopicName>
+          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
+          <depthImageTopicName>depth/image_raw</depthImageTopicName>
+          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
+          <pointCloudTopicName>depth/points</pointCloudTopicName>
+          <frameName>camera_link</frameName>
+          <distortion_k1>0.0</distortion_k1>
+          <distortion_k2>0.0</distortion_k2>
+          <distortion_k3>0.0</distortion_k3>
+          <distortion_t1>0.0</distortion_t1>
+          <distortion_t2>0.0</distortion_t2>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/px4_fast_planner-master/models/d435_camera/model.config
+++ b/px4_fast_planner-master/models/d435_camera/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>D435</name>
+  <version>1.0</version>
+  <sdf version="1.5">d435_camera.sdf</sdf>
+
+  <author>
+    <name>John Hsu</name>
+    <email>hsu@osrfoundation.org</email>
+  </author>
+
+  <description>
+    Intel RealSense D435 depth camera
+  </description>
+</model>

--- a/px4_fast_planner-master/models/iris_depth_camera/iris_depth_camera.sdf
+++ b/px4_fast_planner-master/models/iris_depth_camera/iris_depth_camera.sdf
@@ -18,11 +18,11 @@
     </plugin>
 
     <include>
-      <uri>model://depth_camera_new</uri>
+      <uri>model://d435_camera</uri>
       <pose>0.1 0 0 0 0 0</pose>
     </include>
     <joint name="depth_camera_joint" type="revolute">
-      <child>depth_camera_new::link</child>
+      <child>d435_camera::link</child>
       <parent>iris::base_link</parent>
       <axis>
         <xyz>0 0 1</xyz>


### PR DESCRIPTION
## Summary
- add a `d435_camera` Gazebo model for RealSense
- mount the D435 model on `iris_depth_camera`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6839f3051ba483208937685e781fb7b5